### PR TITLE
Add Crypto Clinic DApp

### DIFF
--- a/whitelist/protocols.json
+++ b/whitelist/protocols.json
@@ -924,3 +924,13 @@
     ]
   }
 ]
+,
+  {
+    "name": "crypto Clinic Dapp",
+    "slug": "crypto-Clinic-Dapp",
+    "twitter": "@Scryptoclinictv",
+    "logo": "CryptoClinicDApp.png",
+    "contracts": [
+      "0xD07A76E931bcBffd56C7b9F92d759032e1306942"
+    ]
+  }


### PR DESCRIPTION

Title

Crypto Clinic (whitelist): add voting contract for taiko

Description

The Crypto Clinic project includes an Arabic podcast and a dedicated website. The podcast aims to simplify Blockchain, Web3, and cryptocurrency concepts for Arabic speakers, making the space more accessible, especially for beginners. The website will feature a home page, an Airdrops page, and an Official Links page, providing a central hub for crypto enthusiasts. Additionally, I'm developing an EVM-based voting application, designed to facilitate decentralized decision-making and empower the community in a transparent and efficient way. The Crypto Clinic DApp will also support users by guiding them through major network competitions and airdrops, making it easier for them to interact with networks like Taiko.