### PR TITLE
add workflow to enforce group approvals

### DIFF
--- a/.github/workflows/group-approvals.yml
+++ b/.github/workflows/group-approvals.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Check Required Approvals
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GROUP_1: "nickytaiko,JMcryptospain,Pigitaiko" 
+          GROUP_1: "nickytaiko,JMcryptospain,Pigitaiko,swarna1101,JBScaled" 
           GROUP_2: "bennettyong,myronrotter,KorbinianK,bearni95" 
         run: |
           GROUP_1_REQUIRED=0

--- a/.github/workflows/group-approvals.yml
+++ b/.github/workflows/group-approvals.yml
@@ -1,0 +1,44 @@
+name: Enforce Group-Based Approvals
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, review_requested]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  enforce_approvals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Required Approvals
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GROUP_1: "nickytaiko,JMcryptospain,Pigitaiko" 
+          GROUP_2: "bennettyong,myronrotter,KorbinianK,bearni95" 
+        run: |
+          GROUP_1_REQUIRED=0
+          GROUP_2_REQUIRED=0
+          PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+
+          # Fetch pull request reviews
+          REVIEWS=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" | jq -r '.[] | select(.state == "APPROVED") | .user.login')
+
+          # Check approvals against each group
+          IFS=',' read -ra GROUP1 <<< "$GROUP_1"
+          IFS=',' read -ra GROUP2 <<< "$GROUP_2"
+
+          for APPROVER in $REVIEWS; do
+            if [[ " ${GROUP1[@]} " =~ " $APPROVER " ]]; then
+              GROUP_1_REQUIRED=1
+            elif [[ " ${GROUP2[@]} " =~ " $APPROVER " ]]; then
+              GROUP_2_REQUIRED=1
+            fi
+          done
+
+          # Validate if both groups have approved
+          if [[ $GROUP_1_REQUIRED -eq 1 && $GROUP_2_REQUIRED -eq 1 ]]; then
+            echo "Required approvals from both groups present."
+          else
+            echo "Approval from both groups is required."
+            exit 1
+          fi

--- a/.github/workflows/group-approvals.yml
+++ b/.github/workflows/group-approvals.yml
@@ -1,7 +1,5 @@
 name: Enforce Group-Based Approvals
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, review_requested]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce group-based approvals for pull requests. The workflow ensures that at least one member from each of two defined groups approves the pull request before it can be merged.

New workflow for group-based approvals:

* [`.github/workflows/group-approvals.yml`](diffhunk://#diff-df413fd092c86aa541d74c9b959484740a3530c8e69aa8ce7a81af32be8ec04eR1-R44): Added a new workflow that triggers on pull request events and checks if the required approvals from two specified groups are present. If approvals from both groups are not present, the workflow fails and prevents the pull request from being merged.